### PR TITLE
include protocol separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,6 +243,7 @@ async function addNode (fundingKey, parentKey, childKey, script) {
   oprParts.push(Buffer.from(txid).toString('hex'))
 
   if (options.file) {
+    oprParts.push(Buffer.from('|').toString('hex'))
     oprParts.push(Buffer.from('19HxigV4QyBv3tHpQVcUEQyq1pzZVdoAut').toString('hex'))
     oprParts.push(fs.readFileSync(options.file).toString('hex'))
     oprParts.push(Buffer.from(options.type).toString('hex'))


### PR DESCRIPTION
B data is being written into what would is actually the "name" and "kwd..." metanet fields.

If there is no separator, there is no programmatic way to parse the data based on the protocol schema alone. You can't tell where meta stops and B begins. Looking for the specific B prefix string is not a solution as that would also be a valid filename or keyword string.

Many apps have been using the | character as a protocol separator.